### PR TITLE
Return full gapi object

### DIFF
--- a/google-plusone-api.html
+++ b/google-plusone-api.html
@@ -24,7 +24,7 @@ Any number of components can use `<google-plusone-api>` elements, and the librar
     defaultUrl: 'https://apis.google.com/js/plusone.js?onload=%%callback%%',
     notifyEvent: 'api-load',
     get api() {
-      return gapi.hangout;
+      return gapi;
     }
   });
 </script>


### PR DESCRIPTION
The JS library includes much more than just `gapi.hangout` so returning the full `gapi` reference makes more sense in my opinion.

I checked and `google-hangout-button` seems to be the only component that depends on `google-plusone-api` so far, I opened another PR there to go along with this change. (https://github.com/GoogleWebComponents/google-hangout-button/pull/5) 
