### PR TITLE
Add root attribute to google-api-loader

### DIFF
--- a/google-client-api.html
+++ b/google-client-api.html
@@ -107,6 +107,7 @@ Element for loading a specific Google API with the Javascript client library.
        * @attribute appId
        * @type string
        */
+      appId: null,
 
       /**
        * Root URL where to load the API from, e.g. 'http://host/apis'.
@@ -116,6 +117,7 @@ Element for loading a specific Google API with the Javascript client library.
        * @attribute root
        * @type string
        */
+      root: null,
 
       // Used to fix events potentially being fired multiple times by
       // core-shared-lib.


### PR DESCRIPTION
Allows override `appId` attribute and thus makes it possible to load an API from an arbitrary URL, including dev App Engine server.

Fixes #19.
