### PR TITLE
Warn if no identifier used loading maps

### DIFF
--- a/google-maps-api.html
+++ b/google-maps-api.html
@@ -122,6 +122,14 @@ Any number of components can use `<google-maps-api>` elements, and the library w
         url += '&client=' + clientId;
       }
 
+      // Log a warning if the user is not using an API Key or Client ID.
+      if (!apiKey && !clientId) {
+        var warning = 'No Google Maps API Key or Client ID specified. ' +
+            'See https://developers.google.com/maps/documentation/javascript/get-api-key ' +
+            'for instructions to get started with a key or client id.';
+        console.warn(warning);
+      }
+
       if (language) {
         url += '&language=' + language;
       }


### PR DESCRIPTION
Log a warning if the Google Maps API is loaded without an API Key or Client ID.

Closes GoogleWebComponents/google-map#260.