### PR TITLE
2.0-preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bower_components*
+bower-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-bower_components
+bower_components*

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "apis"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#2.0-preview",
+    "polymer": "Polymer/polymer#^2.0.0-rc.1",
     "iron-jsonp-library": "PolymerElements/iron-jsonp-library#2.0-preview"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -21,10 +21,21 @@
     "apis"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.0",
-    "iron-jsonp-library": "PolymerElements/iron-jsonp-library#^1.0.0"
+    "polymer": "Polymer/polymer#2.0-preview",
+    "iron-jsonp-library": "PolymerElements/iron-jsonp-library#2.0-preview"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0"
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview"
+  },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "polymer": "Polymer/polymer#^1.0.0",
+        "iron-jsonp-library": "PolymerElements/iron-jsonp-library#^1.0.0"
+      },
+      "devDependencies": {
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0"
+      }
+    }
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,38 +10,43 @@
 <body>
   <div id="messages"></div>
 
-  <template  id="t" is="dom-bind">
+  <dom-module id="demo-element">
+    <template>
 
-    <google-client-loader id="shortener"
-      name="urlshortener"
-      version="v1"
-      on-google-api-load="loadedShortener"></google-client-loader>
-    <google-js-api on-js-api-load="loaded"></google-js-api>
-    <google-plusone-api on-api-load="loaded"></google-plusone-api>
-    <google-realtime-api on-api-load="loaded"></google-realtime-api>
-    <google-maps-api on-api-load="loaded"></google-maps-api>
-    <google-youtube-api on-api-load="loaded"></google-youtube-api>
-    <google-legacy-loader on-api-load="loaded"></google-legacy-loader>
+      <google-client-loader id="shortener"
+        name="urlshortener"
+        version="v1"
+        on-google-api-load="loadedShortener"></google-client-loader>
+      <google-js-api on-js-api-load="loaded"></google-js-api>
+      <google-plusone-api on-api-load="loaded"></google-plusone-api>
+      <google-realtime-api on-api-load="loaded"></google-realtime-api>
+      <google-maps-api on-api-load="loaded"></google-maps-api>
+      <google-youtube-api on-api-load="loaded"></google-youtube-api>
+      <google-legacy-loader on-api-load="loaded"></google-legacy-loader>
 
-  </template>
+    </template>
+    <script>
+      Polymer({
+        is: 'demo-element',
 
-  <script>
-    var t = document.querySelector('#t');
+        loadedShortener: function(event) {
+          var request = event.target.api.url.get({
+            shortUrl: 'http://goo.gl/fbsS'
+          })
+          request.execute(function(resp) {
+            console.log(resp);
+          });
+        },
 
-    t.loadedShortener = function(event) {
-      var request = event.target.api.url.get({
-        shortUrl: 'http://goo.gl/fbsS'
+        loaded: function(e) {
+          document.querySelector('#messages').innerHTML +=
+            e.target.localName + ' loaded' + '<br>';
+          console.log(e.target.localName + ' loaded', event.target.api);
+        }
       })
-      request.execute(function(resp) {
-        console.log(resp);
-      });
-    };
+    </script>
+  </dom-module>
 
-    t.loaded = function(e) {
-      document.querySelector('#messages').innerHTML +=
-        e.target.localName + ' loaded' + '<br>';
-      console.log(e.target.localName + ' loaded', event.target.api);
-    };
-  </script>
+  <demo-element></demo-element>
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,8 +10,8 @@
 <body>
   <div id="messages"></div>
 
-  <dom-module id="demo-element">
-    <template>
+  <dom-bind id="bind">
+    <template id="t" is="dom-bind">
 
       <google-client-loader id="shortener"
         name="urlshortener"
@@ -25,28 +25,27 @@
       <google-legacy-loader on-api-load="loaded"></google-legacy-loader>
 
     </template>
-    <script>
-      Polymer({
-        is: 'demo-element',
-
-        loadedShortener: function(event) {
-          var request = event.target.api.url.get({
-            shortUrl: 'http://goo.gl/fbsS'
-          })
-          request.execute(function(resp) {
-            console.log(resp);
-          });
-        },
-
-        loaded: function(e) {
-          document.querySelector('#messages').innerHTML +=
-            e.target.localName + ' loaded' + '<br>';
-          console.log(e.target.localName + ' loaded', event.target.api);
-        }
+  </dom-bind>
+  <script>
+    // polymer 1.x compatibility
+    t.loadedShortener = function(event) {
+      var request = event.target.api.url.get({
+        shortUrl: 'http://goo.gl/fbsS'
       })
-    </script>
-  </dom-module>
+      request.execute(function(resp) {
+        console.log(resp);
+      });
+    }
 
-  <demo-element></demo-element>
+    t.loaded = function(e) {
+      document.querySelector('#messages').innerHTML +=
+        e.target.localName + ' loaded' + '<br>';
+      console.log(e.target.localName + ' loaded', event.target.api);
+    }
+
+    // Polymer 2.0 compatibility
+    bind.loadedShortener = t.loadedShortener;
+    bind.loaded = t.loaded;
+  </script>
 </body>
 </html>

--- a/google-client-loader.html
+++ b/google-client-loader.html
@@ -162,7 +162,8 @@ For loading `gapi.client` libraries
 
       _fireSuccess: function() {
         this.fire(this.successEventName,
-            { 'name': this.name, 'version': this.version });
+            { 'name': this.name, 'version': this.version },
+            { composed: true });
       },
 
       _fireError: function(response) {
@@ -170,11 +171,13 @@ For loading `gapi.client` libraries
           this.fire(this.errorEventName, {
             'name': this.name,
             'version': this.version,
-            'error': response.error });
+            'error': response.error },
+            { composed: true });
         } else {
           this.fire(this.errorEventName, {
             'name': this.name,
-            'version': this.version });
+            'version': this.version },
+            { composed: true });
         }
       },
 


### PR DESCRIPTION
Requesting creation of a `2.0-preview` branch on GoogleWebComponents/google-apis so I can merge with that instead of master. 

Polymer 2.0 preview. Main changes, dependencies are 2.0 hybrid elements and `this.fire` elements have the `composed: true` flag for bubbling past shadow roots.

working on this to fix incompatibilities with `google-youtube` which is blocking the `2.0-preview` branch of `app-route`.