### PR TITLE
Attach google-js-api to shadow root

### DIFF
--- a/google-client-loader.html
+++ b/google-client-loader.html
@@ -140,7 +140,7 @@ For loading `gapi.client` libraries
       ready: function() {
         this._loader = document.createElement('google-js-api');
           
-        if (!this.shadowRoot) { this.createShadowRoot(); }
+        if (!this.shadowRoot) { this.attachShadow(); }
         this.shadowRoot.appendChild(this._loader);
           
         this.listen(this._loader, 'js-api-load', '_loadClient');

--- a/google-client-loader.html
+++ b/google-client-loader.html
@@ -139,6 +139,7 @@ For loading `gapi.client` libraries
 
       ready: function() {
         this._loader = document.createElement('google-js-api');
+        this.shadowRoot.appendChild(this._loader);
         this.listen(this._loader, 'js-api-load', '_loadClient');
       },
 

--- a/google-client-loader.html
+++ b/google-client-loader.html
@@ -140,7 +140,7 @@ For loading `gapi.client` libraries
       ready: function() {
         this._loader = document.createElement('google-js-api');
           
-        if (!this.shadowRoot) { this.attachShadow(); }
+        if (!this.shadowRoot) { this.attachShadow({mode: 'open'}); }
         this.shadowRoot.appendChild(this._loader);
           
         this.listen(this._loader, 'js-api-load', '_loadClient');

--- a/google-client-loader.html
+++ b/google-client-loader.html
@@ -139,7 +139,10 @@ For loading `gapi.client` libraries
 
       ready: function() {
         this._loader = document.createElement('google-js-api');
+          
+        if (!this.shadowRoot) { this.createShadowRoot(); }
         this.shadowRoot.appendChild(this._loader);
+          
         this.listen(this._loader, 'js-api-load', '_loadClient');
       },
 


### PR DESCRIPTION
As-is, I don't think this works -- the `ready()` never gets called on `google-js-api`. Probably a Polymer 2.0 break?