### PR TITLE
Remove @override warnings when depending on google maps and google js

### DIFF
--- a/google-js-api.js
+++ b/google-js-api.js
@@ -30,6 +30,7 @@ Polymer({
 
   is: 'google-js-api',
 
+  /** @override */
   _template: null,
 
   behaviors: [

--- a/google-maps-api.js
+++ b/google-maps-api.js
@@ -33,6 +33,7 @@ Polymer({
 
   is: 'google-maps-api',
 
+  /** @override */
   _template: null,
 
   behaviors: [


### PR DESCRIPTION
When dependending on these libraries from our package, we get warnings like:
WARNING - [JSC_HIDDEN_INTERFACE_PROPERTY] property _template already defined on interface Polymer_ElementMixin; use @override to override it

This change is to add the recommended @override and remove the warnings.